### PR TITLE
Adapt SPM.mat file paths

### DIFF
--- a/nitools/spm.py
+++ b/nitools/spm.py
@@ -10,15 +10,11 @@ spm.get_info_from_spm_mat()
 ```
 """
 from __future__ import annotations
-from typing import TYPE_CHECKING, List, Optional, Callable
-from os.path import join, normpath, dirname
+from os.path import normpath, dirname
 import numpy as np
 import nitools as nt
-from numpy import stack
 from scipy.io import loadmat
 
-if TYPE_CHECKING:
-    from numpy.typing import NDArray
 
 class SpmGlm:
     """class for handling first-levels GLMs estimated in SPM
@@ -55,12 +51,7 @@ class SpmGlm:
         self.run_number = np.array(self.run_number)
         self.beta_names = np.array(self.beta_names)
         # Get the raw data file name
-        self.rawdata_files = []
-        # SPM stores full absolute paths in the file, so since the data may
-        # have moved we should re-attach it to our know path
-        for fpath in SPM['xY']['P']:
-            c = fpath.find('func')
-            self.rawdata_files.append(join(dirname(self.path), fpath[c:]))
+        self.rawdata_files = [self.relocate_file(p) for p in SPM['xY']['P']]
         # Get the necesssary matrices to reestimate the GLM for getting the residuals
         self.filter_matrices = [k['X0'] for k in SPM['xX']['K']]
         self.reg_of_interest = SPM['xX']['iC']
@@ -68,6 +59,25 @@ class SpmGlm:
         self.eff_df = SPM['xX']['erdf'] # Effective degrees of freedom
         self.weight = SPM['xX']['W'] # Weight matrix for whitening
         self.pinvX = SPM['xX']['pKX'] # Pseudo-inverse of (filtered and weighted) design matrix
+
+    def relocate_file(self, fpath: str) -> str:
+        """SPM file entries to current project directory and OS.
+
+        These are file paths suffixed with two spaces and an index number.
+        They are stored as absolute paths on the computer where it is
+        generated, meaning the project directory, as well as OS-dependent
+        path separator may have changed. This method fixes these.
+
+        Args:
+            fpath (str): SPM-style file path and number from unknown OS
+
+        Returns:
+            str: SPM-style file path
+        """
+        norm_fpath = fpath.replace('\\', '/')
+        base_path = dirname(self.path).replace('\\', '/')
+        c = norm_fpath.find('func')
+        return base_path + '/' + norm_fpath[c:]
 
     def get_betas(self,mask):
         """
@@ -139,4 +149,3 @@ class SpmGlm:
             Y = fdata[scan_bounds[i]:scan_bounds[i+1],:];
             Y = Y - self.filter_matrices[i] @ (self.filter_matrices[i].T @ Y)
         return fdata
-

--- a/nitools/spm.py
+++ b/nitools/spm.py
@@ -11,7 +11,7 @@ spm.get_info_from_spm_mat()
 """
 from __future__ import annotations
 from typing import TYPE_CHECKING, List, Optional, Callable
-from os.path import join, normpath
+from os.path import join, normpath, dirname
 import numpy as np
 import nitools as nt
 from numpy import stack
@@ -55,7 +55,12 @@ class SpmGlm:
         self.run_number = np.array(self.run_number)
         self.beta_names = np.array(self.beta_names)
         # Get the raw data file name
-        self.rawdata_files = SPM['xY']['P']
+        self.rawdata_files = []
+        # SPM stores full absolute paths in the file, so since the data may
+        # have moved we should re-attach it to our know path
+        for fpath in SPM['xY']['P']:
+            c = fpath.find('func')
+            self.rawdata_files.append(join(dirname(self.path), fpath[c:]))
         # Get the necesssary matrices to reestimate the GLM for getting the residuals
         self.filter_matrices = [k['X0'] for k in SPM['xX']['K']]
         self.reg_of_interest = SPM['xX']['iC']

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy >= 1.20.1
 matplotlib >= 3.4.3
 nibabel >= 4.0.2
 pandas >= 1.3.2
+scipy

--- a/tests/test_spm.py
+++ b/tests/test_spm.py
@@ -41,6 +41,13 @@ def test_GLM():
     resms1 = np.mean(residuals**2,axis=0)/spm.eff_df
     assert np.allclose(resms,resms1,atol=1e-4,equal_nan=True),'ResMS are not the same'
 
+def test_relative_paths():
+    # If the data has been moved, we should adapt the paths stored in SPM.mat
+    basedir = os.path.expanduser('~/data/project')
+    spm = SpmGlm(basedir + '/glm_firstlevel')
+    spm.get_info_from_spm_mat()
+    assert spm.rawdata_files[0] == basedir+'/func/uas01_run01.nii,1  '
+
 if __name__=='__main__':
     test_GLM()
     pass


### PR DESCRIPTION
The file paths stored in `SPM.mat` are absolute; when the data is moved to another machine, `SpmGlm` can adjust these paths to new project directory and filesystem separator style.

- [x] prepend base path
- [x] adjust for filesystem